### PR TITLE
Prevent AttributeError when no Emoji is set

### DIFF
--- a/custom_components/discord_game/sensor.py
+++ b/custom_components/discord_game/sensor.py
@@ -118,7 +118,7 @@ def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
                 activity: CustomActivity
                 activity_state = activity.state
                 custom_status = activity.name
-                custom_emoji = activity.emoji.name
+                custom_emoji = activity.emoji.name if activity.emoji else None
                 continue
 
         watcher._game = game


### PR DESCRIPTION
The integration throws an AttributeError when a CustomActivty is set without an emoji. 
`AttributeError: 'NoneType' object has no attribute 'name'`
This can easily be prevented by this one line.