### PR TITLE
Use async/await, pattern matching and ability to use ids

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ sensor:
     members:
       - Username1#1234
       - Username2#1234
+      - 1234567890
 ```
 
 You have to create a Discord bot user and get it's token to be able to use this component.

--- a/custom_components/discord_game/sensor.py
+++ b/custom_components/discord_game/sensor.py
@@ -29,22 +29,19 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-@asyncio.coroutine
-def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
+async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     import discord
     token = config.get(CONF_TOKEN)
     image_format = config.get(CONF_IMAGE_FORMAT)
     bot = discord.Client(loop=hass.loop)
-    yield from bot.login(token)
+    await bot.login(token)
 
-    @asyncio.coroutine
-    def async_stop_server(event):
-        yield from bot.logout()
+    async def async_stop_server(event):
+        await bot.logout()
 
-    @asyncio.coroutine
-    def start_server(event):
+    async def start_server(event):
         hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, async_stop_server)
-        yield from bot.start(token)
+        await bot.start(token)
 
     hass.bus.async_listen_once(EVENT_HOMEASSISTANT_START, start_server)
 

--- a/custom_components/discord_game/sensor.py
+++ b/custom_components/discord_game/sensor.py
@@ -193,8 +193,9 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
 
     watchers = {}
     for member in config.get(CONF_MEMBERS):
-        watcher: DiscordAsyncMemberState = DiscordAsyncMemberState(hass, bot, member)
-        watchers[watcher.name] = watcher
+        if re.match(r"^.*#[0-9]{4}", member):
+            watcher: DiscordAsyncMemberState = DiscordAsyncMemberState(hass, bot, member)
+            watchers[watcher.name] = watcher
     if len(watchers) > 0:
         async_add_entities(watchers.values())
         return True

--- a/custom_components/discord_game/sensor.py
+++ b/custom_components/discord_game/sensor.py
@@ -196,6 +196,11 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
         if re.match(r"^.*#[0-9]{4}", member):
             watcher: DiscordAsyncMemberState = DiscordAsyncMemberState(hass, bot, member)
             watchers[watcher.name] = watcher
+        elif re.match(r"^[0-9]{,20}", member): #Up to 20 digits because 2^64 (snowflake-length) is 20 digits long
+            user = await bot.fetch_user(member)
+            if user:
+                watcher: DiscordAsyncMemberState = DiscordAsyncMemberState(hass, bot, "{}#{}".format(user.name,user.discriminator))
+                watchers[watcher.name] = watcher
     if len(watchers) > 0:
         async_add_entities(watchers.values())
         return True


### PR DESCRIPTION
The first commit updates the coroutine-syntax to the modern asnyc/await syntax.

The second commit matches patterns for usernames. No faulty entity is added. Maybe add a warning in another else.

The last commit adds the ability to use ids and fetches the username. Closes #17 