### PR TITLE
Fix async_forward_entry_setup deprecation in __init__.py

### DIFF
--- a/custom_components/discord_game/__init__.py
+++ b/custom_components/discord_game/__init__.py
@@ -16,9 +16,7 @@ async def async_setup_entry(
     """Set up platform from a ConfigEntry."""
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = entry.data
 
-    hass.async_create_task(
-        hass.config_entries.async_forward_entry_setup(entry, Platform.SENSOR)
-    )
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     return True
 


### PR DESCRIPTION
Addresses the following errors:

1. Detected that custom integration 'discord_game' calls async_forward_entry_setup for integration, discord_game with title: Discord Game and entry_id: ..., which is deprecated, await async_forward_entry_setups instead at custom_components/discord_game/__init__.py, line 19: hass.async_create_task(. This will stop working in Home Assistant 2025.6, please report it to the author of the 'discord_game' custom integration 

2. Detected code that calls async_forward_entry_setup for integration discord_game with title: Discord Game and entry_id: ..., during setup without awaiting async_forward_entry_setup, which can cause the setup lock to be released before the setup is done. This will stop working in Home Assistant 2025.1, please report this issue