### PR TITLE
Fix channelNames is not defined in config_flow.py

### DIFF
--- a/custom_components/discord_game/config_flow.py
+++ b/custom_components/discord_game/config_flow.py
@@ -108,7 +108,7 @@ class DiscordGameConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             _LOGGER.debug("userNames: %s", self.user_names)
 
             self.channel_names = list(self.channels.keys())
-            _LOGGER.debug("channelNames: %s", channelNames)
+            _LOGGER.debug("channelNames: %s", self.channel_names)
         except LoginFailure:
             raise ValueError("Invalid access token")
         finally:


### PR DESCRIPTION
Fixes when setting up the component, after putting in the access token, HA says "Unknown error occurred" with "channelNames is not defined" in the HA log.

Just a small oversight due to the changes made in #66, this variable change was missed.